### PR TITLE
Add option to allow the use of node-resolve accros all format

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -58,6 +58,13 @@ Load a custom plugin to transpile javascript, eg: `js: 'typescript'` then we loa
 
 To disable default Buble transformation, you can set it to `false`.
 
+### resolve
+
+Type: `boolean`<br>
+Default: `undefined`
+
+Resolve external dependencies, it's always `true` in `umd` format.
+
 ### replace
 
 Type: `object`

--- a/src/get-rollup-options.js
+++ b/src/get-rollup-options.js
@@ -95,7 +95,7 @@ export default function (options, format) {
     plugins.push(require('rollup-plugin-replace')(options.replace))
   }
 
-  if (format === 'umd') {
+  if (format === 'umd' || options.resolve) {
     plugins.push(
       require('rollup-plugin-node-resolve')({
         skip: options.skip,

--- a/src/index.js
+++ b/src/index.js
@@ -24,6 +24,7 @@ cli
   .option('replace', 'Set option for rollup-plugin-replace')
   .option('flow', 'Remove flow type annotations', false)
   .option('exports', 'Specific what export mode to use, `default` or `named`')
+  .option('resolve', 'Resolve externals on all format', false)
 
 cli.command('*', 'Bundle with bili', (input, flags) => {
   const options = Object.assign({

--- a/src/index.js
+++ b/src/index.js
@@ -24,7 +24,7 @@ cli
   .option('replace', 'Set option for rollup-plugin-replace')
   .option('flow', 'Remove flow type annotations', false)
   .option('exports', 'Specific what export mode to use, `default` or `named`')
-  .option('resolve', 'Resolve externals on all format', false)
+  .option('resolve', 'Resolve external dependencies', false)
 
 cli.command('*', 'Bundle with bili', (input, flags) => {
   const options = Object.assign({


### PR DESCRIPTION
Sometimes, we need to produce a file (even in ES) with all function/module we depend on (thanks to tree shaking).

And Rollup is really good at this ! 