### PR TITLE
refactor($errorCatch): allow to log detailed error message

### DIFF
--- a/src/bili.js
+++ b/src/bili.js
@@ -95,9 +95,6 @@ export default function(options = {}) {
       })
     })
   ).then(result => {
-    if (options.watch) {
-      return result
-    }
     return result.reduce((res, next, i) => {
       res[allFormats[i]] = next
       return res

--- a/src/bili.js
+++ b/src/bili.js
@@ -62,33 +62,30 @@ export default function(options = {}) {
       const rollupOptions = getRollupOptions(options, format)
       if (options.watch) {
         let init
-        return new Promise(resolve => {
-          const watcher = rollup.watch(rollupOptions)
-          watcher.on('event', event => {
-            switchy({
-              START() {
-                log(format, 'starting', chalk.blue)
-                if (!init) {
-                  init = true
-                  return resolve()
-                }
-              },
-              BUNDLE_START() {},
-              BUNDLE_END() {
-                log(format, 'bundled', chalk.green)
-              },
-              END() {},
-              ERROR() {
-                handleRollupError(event.error)
-              },
-              FATAL() {
-                handleRollupError(event.error)
-              },
-              default() {
-                console.error('unknown event', event)
+        const watcher = rollup.watch(rollupOptions)
+        return watcher.on('event', event => {
+          switchy({
+            START() {
+              log(format, 'starting', chalk.blue)
+              if (!init) {
+                init = true
               }
-            })(event.code)
-          })
+            },
+            BUNDLE_START() {},
+            BUNDLE_END() {
+              log(format, 'bundled', chalk.green)
+            },
+            END() {},
+            ERROR() {
+              handleRollupError(event.error)
+            },
+            FATAL() {
+              handleRollupError(event.error)
+            },
+            default() {
+              console.error('unknown event', event)
+            }
+          })(event.code)
         })
       }
       return rollup.rollup(rollupOptions).then(bundle => {
@@ -98,9 +95,12 @@ export default function(options = {}) {
       })
     })
   ).then(result => {
-    return result.reduce((res, next, i) => {
-      res[allFormats[i]] = next
-      return res
-    }, {})
+    if (!options.watch) {
+      return result.reduce((res, next, i) => {
+        res[allFormats[i]] = next
+        return res
+      }, {})
+    }
+    return result
   })
 }

--- a/src/bili.js
+++ b/src/bili.js
@@ -95,12 +95,12 @@ export default function(options = {}) {
       })
     })
   ).then(result => {
-    if (!options.watch) {
-      return result.reduce((res, next, i) => {
-        res[allFormats[i]] = next
-        return res
-      }, {})
+    if (options.watch) {
+      return result
     }
-    return result
+    return result.reduce((res, next, i) => {
+      res[allFormats[i]] = next
+      return res
+    }, {})
   })
 }

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -20,6 +20,7 @@ function readInPkg(file) {
         pkg: {}
       }
     }
+    throw err
   }
 }
 

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -20,7 +20,6 @@ function readInPkg(file) {
         pkg: {}
       }
     }
-    throw err
   }
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -13,5 +13,7 @@ export function handleRollupError(error) {
     console.log(chalk.dim(`Location: ${error.id}`))
   }
   console.error(error.snippet)
+  console.log()
+  console.log(error)
   process.exitCode = 1
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -12,8 +12,7 @@ export function handleRollupError(error) {
   if (error.id) {
     console.log(chalk.dim(`Location: ${error.id}`))
   }
-  console.error(error.snippet)
+  console.error(error.snippet || error)
   console.log()
-  console.log(error)
   process.exitCode = 1
 }

--- a/test/__snapshots__/index.test.js.snap
+++ b/test/__snapshots__/index.test.js.snap
@@ -1,5 +1,18 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
+exports[`bili it replaces string using rollup-plugin-replace 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+var a = 1;
+var version = '0.0.0';
+
+exports['default'] = a;
+exports.version = version;
+"
+`;
+
 exports[`compress string 1`] = `
 "(function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
@@ -126,19 +139,6 @@ Object.defineProperty(exports, '__esModule', { value: true });
 exports[`it inserts banner 3`] = `
 "/*! bilibili */
 !function(e,t){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?t(exports):\\"function\\"==typeof define&&define.amd?define([\\"exports\\"],t):t(e.index={})}(this,function(e){\\"use strict\\";e.default=1,e.version=\\"__VERSION__\\",Object.defineProperty(e,\\"__esModule\\",{value:!0})});
-"
-`;
-
-exports[`it replaces string using rollup-plugin-replace 1`] = `
-"'use strict';
-
-Object.defineProperty(exports, '__esModule', { value: true });
-
-var a = 1;
-var version = '0.0.0';
-
-exports['default'] = a;
-exports.version = version;
 "
 `;
 

--- a/test/fixtures/bili.config.js
+++ b/test/fixtures/bili.config.js
@@ -1,0 +1,3 @@
+module.exports = {
+  name: 'EGOIST'
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,10 +15,9 @@ function cwd(filePath) {
   return path.join(__dirname, filePath || '')
 }
 
-function Promisify(fn) {
-  const args = arguments
+function Promisify(fn, ...args) {
   return new Promise(resolve => {
-    resolve(fn && fn(...[...args].slice(1)))
+    resolve(fn && fn(...args))
   })
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -80,7 +80,8 @@ describe('bili', () => {
       exports: 'named',
       watch: true
     })
-    watchers.forEach(watcher => {
+    Object.keys(watchers).forEach(format => {
+      const watcher = watchers[format]
       expect(watcher instanceof EventEmitter).toBeTruthy()
       watcher.on('event', event => {
         switchy({

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -7,6 +7,8 @@ import switchy from 'switchy'
 
 import bili from '../src/bili'
 import { handleRollupError } from '../src/utils'
+import getConfig from '../src/get-config'
+import getRollupOptions from '../src/get-rollup-options'
 import log from '../src/log'
 
 function cwd(filePath) {
@@ -226,6 +228,13 @@ test('should handle rollup error', () => {
   })
   expect(process.exitCode).toBe(1)
   process.exitCode = 0
+})
+
+test('should get correct package config', () => {
+  const pkgConfig = getConfig('fixtures/bili.config.js')
+  expect(pkgConfig.name).toBe('EGOIST')
+  expect(typeof pkgConfig.pkg).toBe('object')
+  expect(JSON.stringify(pkgConfig.pkg)).toBe('{}')
 })
 
 describe('compress', () => {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -230,7 +230,8 @@ test('should handle rollup error', () => {
 })
 
 test('should get correct package config', () => {
-  const pkgConfig = getConfig('fixtures/bili.config.js')
+  const pkgConfig = getConfig(cwd('fixtures/bili.config.js'))
+  console.log(pkgConfig)
   expect(pkgConfig.name).toBe('EGOIST')
   expect(typeof pkgConfig.pkg).toBe('object')
   expect(JSON.stringify(pkgConfig.pkg)).toBe('{}')


### PR DESCRIPTION
# Overview

- Add detailed error log
- in `watch` mode, bili return `watchers` instead of `undefined`
- Increase cov from `71%` to `97%+` (In local is 99.36%...).

# More

When I use `bili` to bundle an module with complicated dependencies, it throw error:

![image](https://user-images.githubusercontent.com/23133919/31070237-29232eac-a725-11e7-9203-d0ccd185e774.png)

But in that case I can't get my error detail, so I can't know why it's failing

So I open this PR, now the error log will be like this which it's human to let me know the error primary cause:

![image](https://user-images.githubusercontent.com/23133919/31070287-5cf15114-a725-11e7-86c9-c87a64272571.png)

> Digression: I have to blow a wave of `bili`, so fucking good to use 👏




