### PR TITLE
Improve logging experience

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "stringify-author": "^0.1.3",
     "text-table": "^0.2.0",
     "uglify-es": "^3.3.4",
-    "use-config": "^2.0.3"
+    "use-config": "^2.0.4"
   },
   "devDependencies": {
     "babel-cli": "6.26.0",

--- a/src/cli.js
+++ b/src/cli.js
@@ -1,18 +1,21 @@
 #!/usr/bin/env node
 import cac from 'cac'
 import Bili from '.'
-import { getBiliConfig } from './get-config'
 
 const cli = cac()
 
 cli
   .command('*', 'Bundle library', async (input, flags) => {
-    const config = await getBiliConfig()
-    return Bili.write({
+    const options = {
       input,
-      ...config,
       ...flags
-    })
+    }
+    if (options.debug) {
+      options.logLevel = 4
+    } else if (options.quiet) {
+      options.logLevel = 1
+    }
+    return Bili.write(options)
   })
   .option('watch', {
     desc: 'Build and watch files',
@@ -62,13 +65,14 @@ cli
     desc:
       'Content to insert to the top of bundle file, boolean or string or object'
   })
-  .option('inspectRollup', {
-    desc: 'Inspect Rollup options'
+  .option('debug', {
+    desc: 'Show debug logs'
   })
-  .option('inspectOptions', {
-    desc: 'Inspect Bili options'
+  .option('quiet', {
+    desc: 'Show error logs only'
   })
-
-cli.on('error', err => Bili.handleError(err))
+  .option('no-logUpdate', {
+    desc: 'Disable logUpdate'
+  })
 
 cli.parse()

--- a/src/emoji.js
+++ b/src/emoji.js
@@ -1,0 +1,10 @@
+const supportsEmoji =
+  process.platform !== 'win32' || process.env.TERM === 'xterm-256color'
+
+// Fallback symbols for Windows from https://en.wikipedia.org/wiki/Code_page_437
+export default {
+  progress: supportsEmoji ? '⏳' : '∞',
+  success: supportsEmoji ? '✨' : '√',
+  error: supportsEmoji ? '🚨' : '×',
+  warning: supportsEmoji ? '⚠️' : '‼'
+}

--- a/src/get-config.js
+++ b/src/get-config.js
@@ -1,4 +1,6 @@
+import path from 'path'
 import UseConfig from 'use-config'
+import chalk from 'chalk'
 
 export function getBabelConfig({ jsx }) {
   return {
@@ -6,11 +8,14 @@ export function getBabelConfig({ jsx }) {
   }
 }
 
-export async function getBiliConfig() {
+export function getBiliConfig(logger) {
   const useConfig = new UseConfig({
     name: 'bili',
     files: ['package.json', '{name}.config.js', '.{name}rc']
   })
-  const { config } = await useConfig.load()
+  const { path: configPath, config } = useConfig.loadSync()
+  if (configPath) {
+    logger.debug(chalk.bold(`Bili config file: ${path.relative(process.cwd(), configPath)}`))
+  }
   return config
 }

--- a/src/handle-error.js
+++ b/src/handle-error.js
@@ -1,38 +1,12 @@
 import chalk from 'chalk'
-import { logAndPersist } from './utils'
 
-function logError(message) {
-  logAndPersist('🚨 ', message)
-}
-
-export function handleError(err) {
+export function handleError(logger, err) {
   process.exitCode = process.exitCode || 1
-  let msg = ''
-  if (err.code === 'PLUGIN_ERROR') {
-    msg += chalk.red(`🚨  Error found by "${err.plugin}" plugin:`)
-    if (err.codeFrame) {
-      msg += `\n${err.message}\n${err.codeFrame}`
-    } else if (err.snippet) {
-      msg += `\n${err.message}\n${err.snippet}`
-    } else {
-      msg += `\n${err.stack}`
-    }
-    return logAndPersist(msg)
-  }
-
   if (err.message.includes('You must supply options.name for UMD bundles')) {
-    return logError(`You must supply ${chalk.green('options.moduleName')} for UMD bundles, the easiest way is to use ${chalk.green('--moduleName')} flag.\n${getDocRef('api', 'modulename')}`)
+    return logger.error(`You must supply ${chalk.green('options.moduleName')} for UMD bundles, the easiest way is to use ${chalk.green('--moduleName')} flag.\n${getDocRef('api', 'modulename')}`)
   }
 
-  if (err.name === 'BiliError') {
-    return logError(err.message)
-  }
-
-  if (err.frame) {
-    msg += `${err.frame}\n`
-  }
-  msg += err.stack
-  logError(msg)
+  logger.error(err)
 }
 
 export function getDocRef(page, id) {

--- a/src/logger.js
+++ b/src/logger.js
@@ -1,0 +1,107 @@
+import logUpdate from 'log-update'
+import emoji from './emoji'
+
+const prettyError = err => {
+  let message
+  let stack
+  if (err.plugin) {
+    message = `(${err.plugin}) ${err.message}`
+    stack = err.codeFrame || err.snippet || err.stack
+  } else {
+    message = err.message
+    stack = err.stack
+  }
+
+  return {
+    message,
+    stack
+  }
+}
+
+export default class Logger {
+  constructor(options = {}) {
+    this.logLevel = typeof options.logLevel === 'number' ? options.logLevel : 3
+    this.useLogUpdate =
+      typeof options.logUpdate === 'boolean' ? options.logUpdate : true
+  }
+
+  clear() {
+    if (this.useLogUpdate) {
+      logUpdate.clear()
+    }
+  }
+
+  write(message, persistent = false) {
+    if (persistent) {
+      this.clear()
+      console.log(message)
+      return
+    }
+    if (this.useLogUpdate) {
+      logUpdate(message)
+    } else {
+      console.log(message)
+    }
+  }
+
+  // Debug message
+  // Always persisted
+  debug(message) {
+    if (this.logLevel < 4) {
+      return
+    }
+
+    this.write(message, true)
+  }
+
+  // Normal log
+  // Persist by default
+  log(message, update) {
+    if (this.logLevel < 3) {
+      return
+    }
+
+    this.write(message, !update)
+  }
+
+  // Warn status
+  warn(message) {
+    if (this.logLevel < 2) {
+      return
+    }
+
+    this.status(emoji.warning, message)
+  }
+
+  // Error status
+  error(err) {
+    if (this.logLevel < 1) {
+      return
+    }
+
+    if (typeof err === 'string') {
+      return this.status(emoji.error, err)
+    }
+
+    let { message, stack } = prettyError(err)
+
+    this.status(emoji.error, message)
+    console.log(stack)
+  }
+
+  // Status message should be persisted
+  // Unless `update` is set
+  // Mainly used in `progress-plugin.js`
+  status(emoji, message, update) {
+    if (this.logLevel < 3) {
+      return
+    }
+
+    if (update && this.useLogUpdate) {
+      return logUpdate(`${emoji}  ${message}`)
+    }
+
+    this.clear()
+    console.log(`${emoji}  ${message}`)
+  }
+}

--- a/src/progress-plugin.js
+++ b/src/progress-plugin.js
@@ -1,15 +1,19 @@
 import path from 'path'
 import chalk from 'chalk'
-import logUpdate from 'log-update'
+import emoji from './emoji'
 
-export default () => {
+export default ({ logger }) => {
   let bundling = 0
   return {
     name: 'bili-progress',
     transform(code, id) {
-      logUpdate(`Bundling ${chalk.cyan(++bundling)} file${
-        bundling > 1 ? 's' : ''
-      }: ${chalk.green(path.relative(process.cwd(), id))}`)
+      logger.status(
+        emoji.progress,
+        `Bundling ${chalk.cyan(++bundling)} file${
+          bundling > 1 ? 's' : ''
+        }: ${chalk.green(path.relative(process.cwd(), id))}`,
+        true
+      )
     },
     ongenerate() {
       bundling = 0

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,6 +1,0 @@
-import logUpdate from 'log-update'
-
-export function logAndPersist(...args) {
-  logUpdate(...args)
-  logUpdate.done()
-}

--- a/yarn.lock
+++ b/yarn.lock
@@ -4895,9 +4895,9 @@ unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
 
-use-config@^2.0.3:
-  version "2.0.3"
-  resolved "https://registry.yarnpkg.com/use-config/-/use-config-2.0.3.tgz#ee8cda5b2874f953784b8372b61b0fa18d6b5942"
+use-config@^2.0.4:
+  version "2.0.4"
+  resolved "https://registry.yarnpkg.com/use-config/-/use-config-2.0.4.tgz#1e14e5dbc600533aa5cd1b35d43a5be849b45b0c"
   dependencies:
     load-json-file "^2.0.0"
     path-exists "^3.0.0"


### PR DESCRIPTION
![preview](https://cdn.rawgit.com/egoist/d40bcaf7e469da3c65fcbc2d50a137e0/raw/37c6f8e8c06d06cda3d3ee52365731731facf071/bili.svg)

By default it runs in `verbose` mode, however you can control the log level:

- `--debug`: Be even more verbose
- `--quiet`: Error only

To disable progress bars, use `--no-logUpdate`