### PR TITLE
Feat: clean build target with --cleanDest flag

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -36,6 +36,10 @@ cli
     desc: 'Output target (default: "browser")',
     alias: 't'
   })
+  .option('cleanDest', {
+    desc: 'Clean the output directory before building',
+    alias: 'clean'
+  })
   .option('moduleName', {
     desc: 'Module name for UMD/IIFE bundle'
   })

--- a/src/index.js
+++ b/src/index.js
@@ -162,6 +162,11 @@ export default class Bili extends EventEmitter {
     return path.resolve(this.options.cwd, ...args)
   }
 
+  isSubpath(target) {
+    const relativePath = path.relative(this.options.cwd, target)
+    return relativePath.length > 0 && !/^\.\./.test(relativePath)
+  }
+
   loadUserPlugins({ plugins, filename }) {
     // eslint-disable-next-line array-callback-return
     return plugins.map(pluginName => {
@@ -515,7 +520,9 @@ export default class Bili extends EventEmitter {
     )
 
     // clean the desination path if writing and the cleanDest flag is set
-    if (write && this.options.cleanDest) await fs.emptyDir(this.options.outDir)
+    if (write && this.options.cleanDest && this.isSubpath(this.options.outDir)) {
+      await fs.emptyDir(this.options.outDir)
+    }
 
     const multipleEntries = inputFiles.length > 1
     const actions = options.map(async option => {

--- a/src/index.js
+++ b/src/index.js
@@ -514,6 +514,9 @@ export default class Bili extends EventEmitter {
       []
     )
 
+    // clean the desination path if writing and the cleanDest flag is set
+    if (write && this.options.cleanDest) await fs.emptyDir(this.options.outDir)
+
     const multipleEntries = inputFiles.length > 1
     const actions = options.map(async option => {
       const { inputOptions, outputOptions } = await this.createConfig(option, {

--- a/src/index.js
+++ b/src/index.js
@@ -163,8 +163,9 @@ export default class Bili extends EventEmitter {
   }
 
   isSubpath(target) {
-    const relativePath = path.relative(this.options.cwd, target)
-    return relativePath.length > 0 && !/^\.\./.test(relativePath)
+    const cwd = this.resolveCwd() + path.sep
+    const targetPath = this.resolveCwd(target)
+    return cwd !== targetPath && targetPath.startsWith(cwd)
   }
 
   loadUserPlugins({ plugins, filename }) {


### PR DESCRIPTION
Closes #83 

Optionally removes the destination path before performing the build.

- Adds `--cleanDest` flag (alias `--clean`)
- Clean path based on `--outDir`, using the `--cleanDest` flag, but only when writing the bundle

Happy to add tests if you're actually interested in this feature.