### PR TITLE
fix: no such file or directory ***.rpt2_cache***

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -411,6 +411,7 @@ export default class Bili extends EventEmitter {
         transformJS &&
           jsPlugin({
             exclude: 'node_modules/**',
+            ...(jsPluginName === 'typescript2' ? { clean: true } : {}),
             ...jsOptions
           }),
         inline &&


### PR DESCRIPTION
使用 `typescript`，且 `format` 包含 `es` 时，在 Windows 上出错：

```bash
Error: ENOENT: no such file or directory, rename '****\.rpt2_cache\rpt2_c8ecf1c17783670b3327dbfe8133c692e806856e\code\cache_' -> '****\.rpt2_cache\rpt2_c8ecf1c17783670b3327dbfe8133c692e806856e\code\cache'
```

![image](https://user-images.githubusercontent.com/13151189/46903492-61a9b500-cf08-11e8-9c6b-d37bfc5226f8.png)
