### PR TITLE
fix: use `mainFields`

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rollup-plugin-commonjs": "^9.2.0",
     "rollup-plugin-hashbang": "^2.2.2",
     "rollup-plugin-json": "^3.1.0",
-    "rollup-plugin-node-resolve": "^4.0.1",
+    "rollup-plugin-node-resolve": "^4.2.3",
     "rollup-plugin-postcss": "^2.0.3",
     "rollup-plugin-replace": "^2.1.0",
     "rollup-plugin-terser": "^4.0.2"

--- a/src/plugins/node-resolve.ts
+++ b/src/plugins/node-resolve.ts
@@ -14,8 +14,7 @@ export default (options: Options) => {
   const plugin = require('rollup-plugin-node-resolve')({
     extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
     preferBuiltins: true,
-    jsnext: true,
-    module: true,
+    mainFields: ['module', 'jsnext', 'main', 'browser'],
     browser: options.browser
   })
 

--- a/src/plugins/node-resolve.ts
+++ b/src/plugins/node-resolve.ts
@@ -14,7 +14,7 @@ export default (options: Options) => {
   const plugin = require('rollup-plugin-node-resolve')({
     extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
     preferBuiltins: true,
-    mainFields: ['module', 'jsnext', 'main', 'browser'],
+    mainFields: ['module', 'jsnext:main', 'main', 'browser'],
     browser: options.browser
   })
 

--- a/src/plugins/node-resolve.ts
+++ b/src/plugins/node-resolve.ts
@@ -14,8 +14,12 @@ export default (options: Options) => {
   const plugin = require('rollup-plugin-node-resolve')({
     extensions: ['.js', '.json', '.jsx', '.ts', '.tsx'],
     preferBuiltins: true,
-    mainFields: ['module', 'jsnext:main', 'main', 'browser'],
-    browser: options.browser
+    mainFields: [
+      options.browser && 'browser',
+      'module',
+      'jsnext:main',
+      'main'
+    ].filter(Boolean)
   })
 
   return {

--- a/yarn.lock
+++ b/yarn.lock
@@ -947,7 +947,7 @@
   resolved "https://registry.npmjs.org/@types/resolve-from/-/resolve-from-4.0.0.tgz#55538ffe8e35c3116a4cebf814ce1a1f1d663fcc"
   integrity sha512-LjkxahYnTBr75YRCEI/FQnQVfP4fP69koNW+3bmSkZuiSCkXkTJpfl7SPcZ4biXfmZHduoVLElP4VWBhex+0zQ==
 
-"@types/resolve@^0.0.8":
+"@types/resolve@0.0.8", "@types/resolve@^0.0.8":
   version "0.0.8"
   resolved "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.8.tgz#f26074d238e02659e323ce1a13d041eee280e194"
   integrity sha512-auApPaJf3NPfe18hSoJkp8EbZzer2ISk7o8mCC3M9he/a04+gbMF97NkpD2S8riMGvm4BMRI59/SZQSaLTKpsQ==
@@ -1676,6 +1676,11 @@ builtin-modules@^3.0.0:
   version "3.0.0"
   resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.0.0.tgz#1e587d44b006620d90286cc7a9238bbc6129cab1"
   integrity sha512-hMIeU4K2ilbXV6Uv93ZZ0Avg/M91RaKXucQ+4me2Do1txxBDyDZWCBa5bJSLqoNTRpXTLwEzIk1KmloenDDjhg==
+
+builtin-modules@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.npmjs.org/builtin-modules/-/builtin-modules-3.1.0.tgz#aad97c15131eb76b65b50ef208e7584cd76a7484"
+  integrity sha512-k0KL0aWZuBt2lrxrcASWDfwOLMnodeQjodT/1SxEQAXsHANgo6ZC/VEaSEHCXt7aSTZ4/4H5LKa+tBXmW7Vtvw==
 
 builtins@^1.0.3:
   version "1.0.3"
@@ -7819,12 +7824,13 @@ rollup-plugin-json@^3.1.0:
   dependencies:
     rollup-pluginutils "^2.3.1"
 
-rollup-plugin-node-resolve@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.0.1.tgz#f95765d174e5daeef9ea6268566141f53aa9d422"
-  integrity sha512-fSS7YDuCe0gYqKsr5OvxMloeZYUSgN43Ypi1WeRZzQcWtHgFayV5tUSPYpxuaioIIWaBXl6NrVk0T2/sKwueLg==
+rollup-plugin-node-resolve@^4.2.3:
+  version "4.2.3"
+  resolved "https://registry.npmjs.org/rollup-plugin-node-resolve/-/rollup-plugin-node-resolve-4.2.3.tgz#638a373a54287d19fcc088fdd1c6fd8a58e4d90a"
+  integrity sha512-r+WaesPzdGEynpLZLALFEDugA4ACa5zn7bc/+LVX4vAXQQ8IgDHv0xfsSvJ8tDXUtprfBtrDtRFg27ifKjcJTg==
   dependencies:
-    builtin-modules "^3.0.0"
+    "@types/resolve" "0.0.8"
+    builtin-modules "^3.1.0"
     is-module "^1.0.0"
     resolve "^1.10.0"
 


### PR DESCRIPTION
Fix `node-resolve` plugin deprecated warning. 

```
node-resolve: setting options.module is deprecated, please override options.mainFields instead
node-resolve: setting options.jsnext is deprecated, please override options.mainFields instead
```

Order of `mainFields` is optional. Please tell to resort it if needed :)