### PR TITLE
fix: handle rollup FATAL events on watch

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -579,7 +579,7 @@ export class Bundler {
       )
       const watcher = watch(configs)
       watcher.on('event', e => {
-        if (e.code === 'ERROR') {
+        if (e.code === 'ERROR' || e.code === 'FATAL') {
           logger.error(e.error.message)
         }
       })


### PR DESCRIPTION
Solves #184 
Currently if there's an error while bundling with watch mode on `bili` hangs. The way I tested it is that I added `lodash` as a peerDependency to my typescript package, added an import statement from lodash and it made bili hang. With this fix bili will print out the error it gets from Rollup/tsc and stop (as it's a `FATAL` error).