### PR TITLE
Resolve scoped plugins 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -356,6 +356,12 @@ export class Bundler {
 
       const isOfficialBuiltin = pkg.dependencies[`@rollup/plugin-${name}`]
 
+      const isScoped = (name: string) => /^@[^/]+\//.test(name)
+
+      const normalizeName = (name: string) => {
+        return name.replace(/^@([^/]+)\//, (_, m1) => `@${m1}/rollup-plugin-`)
+      }
+
       const plugin =
         name === 'babel'
           ? await import('./plugins/babel')
@@ -369,6 +375,8 @@ export class Bundler {
           ? require(`rollup-plugin-${name}`)
           : isOfficialBuiltin
           ? require(`@rollup/plugin-${name}`)
+          : isScoped(name)
+          ? this.localRequire(normalizeName(name))
           : this.localRequire(`rollup-plugin-${name}`)
 
       if (name === 'terser') {
@@ -463,8 +471,8 @@ export class Bundler {
       // Since we only output to `.js` now
       // Probably remove it in the future
       .replace(/\[ext\]/, '.js')
- 
-    if (rollupFormat === 'esm')  {
+
+    if (rollupFormat === 'esm') {
       fileName = fileName.replace(/\[format\]/, 'esm')
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -359,7 +359,9 @@ export class Bundler {
       const isScoped = (name: string) => /^@[^/]+\//.test(name)
 
       const normalizeName = (name: string) => {
-        return name.replace(/^@([^/]+)\//, (_, m1) => `@${m1}/rollup-plugin-`)
+        return name.replace(/^@([^/]+)\/(rollup-)?(plugin-)?/, (_, m1) => {
+          return m1 === 'rollup' ? `@rollup/plugin-` : `@${m1}/rollup-plugin-`
+        })
       }
 
       const plugin =
@@ -369,8 +371,6 @@ export class Bundler {
           ? nodeResolvePlugin
           : name === 'progress'
           ? progressPlugin
-          : name.startsWith('@rollup/')
-          ? this.localRequire(name)
           : isCommunityBuiltin
           ? require(`rollup-plugin-${name}`)
           : isOfficialBuiltin

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -168,6 +168,25 @@ exports.another = another;
 "
 `;
 
+exports[`custom scoped rollup plugin (shorthand): custom scoped rollup plugin (shorthand) dist/index.js 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const tt = 'is there anything?';
+
+function afun() {
+  return tt;
+}
+
+function another() {
+  return afun();
+}
+
+exports.another = another;
+"
+`;
+
 exports[`custom scoped rollup plugin: custom scoped rollup plugin dist/index.js 1`] = `
 "'use strict';
 

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
+    "@foo/rollup-plugin-bar": "../stubs/@foo/rollup-plugin-bar",
     "@rollup/plugin-strip": "^1.3.2",
     "rollup-plugin-prettier": "^0.5.0",
     "rollup-plugin-strip": "^1.2.0",

--- a/test/fixtures/yarn.lock
+++ b/test/fixtures/yarn.lock
@@ -2,6 +2,9 @@
 # yarn lockfile v1
 
 
+"@foo/rollup-plugin-bar@../stubs/@foo/rollup-plugin-bar":
+  version "0.0.0"
+
 "@rollup/plugin-strip@^1.3.2":
   version "1.3.2"
   resolved "https://registry.npmjs.org/@rollup/plugin-strip/-/plugin-strip-1.3.2.tgz#9f52e99add99b835a4a3c14e02385f3726514923"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,6 +1,5 @@
 import path from 'path'
 import { Bundler, Config, Options } from '../src'
-import { RollupConfig } from '../src/types'
 
 process.env.BABEL_ENV = 'anything-not-test'
 
@@ -15,24 +14,6 @@ function generate(config: Config, options: Options) {
     ...options
   })
   return bundler.run()
-}
-
-function getRollupConfig(
-  config: Config,
-  options: Options
-): Promise<RollupConfig> {
-  return new Promise(resolve => {
-    generate(
-      {
-        ...config,
-        extendRollupConfig: config => {
-          resolve(config)
-          return config
-        }
-      },
-      options
-    )
-  })
 }
 
 function snapshot(
@@ -63,18 +44,17 @@ function snapshot(
 }
 
 test('resolve scoped plugins', async () => {
-  const { inputConfig } = await getRollupConfig(
+  const callback = jest.fn()
+  await generate(
     {
       input: 'index.js',
       plugins: {
-        '@foo/bar': true
+        '@foo/bar': { callback }
       }
     },
     { rootDir: fixture('defaults') }
   )
-  expect(
-    inputConfig.plugins.find(plugin => plugin.name === '@foo/bar')
-  ).toBeTruthy()
+  expect(callback).toHaveBeenCalledWith('@foo/bar')
 })
 
 snapshot({

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -1,5 +1,6 @@
 import path from 'path'
 import { Bundler, Config, Options } from '../src'
+import { RollupConfig } from '../src/types'
 
 process.env.BABEL_ENV = 'anything-not-test'
 
@@ -14,6 +15,24 @@ function generate(config: Config, options: Options) {
     ...options
   })
   return bundler.run()
+}
+
+function getRollupConfig(
+  config: Config,
+  options: Options
+): Promise<RollupConfig> {
+  return new Promise(resolve => {
+    generate(
+      {
+        ...config,
+        extendRollupConfig: config => {
+          resolve(config)
+          return config
+        }
+      },
+      options
+    )
+  })
 }
 
 function snapshot(
@@ -42,6 +61,21 @@ function snapshot(
     }
   })
 }
+
+test('resolve scoped plugins', async () => {
+  const { inputConfig } = await getRollupConfig(
+    {
+      input: 'index.js',
+      plugins: {
+        '@foo/bar': true
+      }
+    },
+    { rootDir: fixture('defaults') }
+  )
+  expect(
+    inputConfig.plugins.find(plugin => plugin.name === '@foo/bar')
+  ).toBeTruthy()
+})
 
 snapshot({
   title: 'defaults',

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -11,7 +11,7 @@ function generate(config: Config, options: Options) {
   const bundler = new Bundler(config, {
     logLevel: 'quiet',
     configFile: false,
-    ...options
+    ...options,
   })
   return bundler.run()
 }
@@ -20,7 +20,7 @@ function snapshot(
   {
     title,
     input,
-    cwd
+    cwd,
   }: { title: string; input: string | string[]; cwd?: string },
   config?: Config
 ) {
@@ -28,10 +28,10 @@ function snapshot(
     const { bundles } = await generate(
       {
         input,
-        ...config
+        ...config,
       },
       {
-        rootDir: cwd
+        rootDir: cwd,
       }
     )
     for (const bundle of bundles) {
@@ -49,8 +49,8 @@ test('resolve scoped plugins', async () => {
     {
       input: 'index.js',
       plugins: {
-        '@foo/bar': { callback }
-      }
+        '@foo/bar': { callback },
+      },
     },
     { rootDir: fixture('defaults') }
   )
@@ -60,17 +60,17 @@ test('resolve scoped plugins', async () => {
 snapshot({
   title: 'defaults',
   input: 'index.js',
-  cwd: fixture('defaults')
+  cwd: fixture('defaults'),
 })
 
 snapshot(
   {
     title: 'banner:true default',
     input: 'index.js',
-    cwd: fixture('banner/default')
+    cwd: fixture('banner/default'),
   },
   {
-    banner: true
+    banner: true,
   }
 )
 
@@ -78,15 +78,15 @@ snapshot(
   {
     title: 'banner:object',
     input: 'default.js',
-    cwd: fixture()
+    cwd: fixture(),
   },
   {
     banner: {
       author: 'author',
       license: 'GPL',
       name: 'name',
-      version: '1.2.3'
-    }
+      version: '1.2.3',
+    },
   }
 )
 
@@ -94,10 +94,10 @@ snapshot(
   {
     title: 'banner:string',
     input: 'default.js',
-    cwd: fixture()
+    cwd: fixture(),
   },
   {
-    banner: 'woot'
+    banner: 'woot',
   }
 )
 
@@ -105,10 +105,10 @@ snapshot(
   {
     title: 'exclude file',
     input: 'index.js',
-    cwd: fixture('exclude-file')
+    cwd: fixture('exclude-file'),
   },
   {
-    externals: ['./foo.js']
+    externals: ['./foo.js'],
   }
 )
 
@@ -116,11 +116,11 @@ snapshot(
   {
     title: 'extendOptions',
     input: ['foo.js', 'bar.js'],
-    cwd: fixture('extend-options')
+    cwd: fixture('extend-options'),
   },
   {
     output: {
-      format: ['umd', 'umd-min', 'cjs']
+      format: ['umd', 'umd-min', 'cjs'],
     },
     extendConfig(config, { format }) {
       if (format === 'umd') {
@@ -130,7 +130,7 @@ snapshot(
         config.output.moduleName = 'min'
       }
       return config
-    }
+    },
   }
 )
 
@@ -138,54 +138,54 @@ snapshot(
   {
     title: 'bundle-node-modules',
     input: 'index.js',
-    cwd: fixture('bundle-node-modules')
+    cwd: fixture('bundle-node-modules'),
   },
   {
-    bundleNodeModules: true
+    bundleNodeModules: true,
   }
 )
 
 snapshot({
   title: 'async',
   input: 'index.js',
-  cwd: fixture('async')
+  cwd: fixture('async'),
 })
 
 snapshot({
   title: 'babel:with-config',
   input: 'index.js',
-  cwd: fixture('babel/with-config')
+  cwd: fixture('babel/with-config'),
 })
 
 snapshot(
   {
     title: 'babel:disable-config',
     input: 'index.js',
-    cwd: fixture('babel/with-config')
+    cwd: fixture('babel/with-config'),
   },
   {
     babel: {
-      babelrc: false
-    }
+      babelrc: false,
+    },
   }
 )
 
 snapshot({
   title: 'babel:object-rest-spread',
   input: 'index.js',
-  cwd: fixture('babel/object-rest-spread')
+  cwd: fixture('babel/object-rest-spread'),
 })
 
 snapshot(
   {
     title: 'uglify',
     input: 'index.js',
-    cwd: fixture('uglify')
+    cwd: fixture('uglify'),
   },
   {
     output: {
-      format: 'cjs-min'
-    }
+      format: 'cjs-min',
+    },
   }
 )
 
@@ -193,37 +193,37 @@ snapshot(
   {
     title: 'inline-certain-modules',
     input: 'index.js',
-    cwd: fixture('inline-certain-modules')
+    cwd: fixture('inline-certain-modules'),
   },
   {
-    bundleNodeModules: ['fake-module']
+    bundleNodeModules: ['fake-module'],
   }
 )
 
 snapshot({
   title: 'vue plugin',
   input: 'component.vue',
-  cwd: fixture('vue')
+  cwd: fixture('vue'),
 })
 
 snapshot({
   title: 'Typescript',
   input: 'index.ts',
-  cwd: fixture('typescript')
+  cwd: fixture('typescript'),
 })
 
 snapshot(
   {
     title: 'custom rollup plugin',
     input: 'index.js',
-    cwd: fixture('custom-rollup-plugin')
+    cwd: fixture('custom-rollup-plugin'),
   },
   {
     plugins: {
       strip: {
-        functions: ['console.log']
-      }
-    }
+        functions: ['console.log'],
+      },
+    },
   }
 )
 
@@ -231,14 +231,29 @@ snapshot(
   {
     title: 'custom scoped rollup plugin',
     input: 'index.js',
-    cwd: fixture('custom-scoped-rollup-plugin')
+    cwd: fixture('custom-scoped-rollup-plugin'),
   },
   {
     plugins: {
       '@rollup/plugin-strip': {
-        functions: ['console.log']
-      }
-    }
+        functions: ['console.log'],
+      },
+    },
+  }
+)
+
+snapshot(
+  {
+    title: 'custom scoped rollup plugin (shorthand)',
+    input: 'index.js',
+    cwd: fixture('custom-scoped-rollup-plugin'),
+  },
+  {
+    plugins: {
+      '@rollup/strip': {
+        functions: ['console.log'],
+      },
+    },
   }
 )
 
@@ -246,14 +261,14 @@ snapshot(
   {
     title: '`@rollup/plugin-replace` can accepts custom options',
     input: 'index.js',
-    cwd: fixture('custom-scoped-rollup-plugin/replace')
+    cwd: fixture('custom-scoped-rollup-plugin/replace'),
   },
   {
     plugins: {
       replace: {
-        'process.env.NODE_ENV': JSON.stringify('production')
-      }
-    }
+        'process.env.NODE_ENV': JSON.stringify('production'),
+      },
+    },
   }
 )
 
@@ -261,12 +276,12 @@ snapshot(
   {
     title: 'target:browser',
     input: 'index.js',
-    cwd: fixture('target/browser')
+    cwd: fixture('target/browser'),
   },
   {
     output: {
-      target: 'browser'
-    }
+      target: 'browser',
+    },
   }
 )
 
@@ -274,13 +289,13 @@ snapshot(
   {
     title: 'umd and iife should drop process.env.NODE_ENV',
     input: 'index.js',
-    cwd: fixture('format')
+    cwd: fixture('format'),
   },
   {
     output: {
       format: ['umd', 'umd-min', 'iife', 'iife-min'],
-      moduleName: 'dropNodeEnv'
-    }
+      moduleName: 'dropNodeEnv',
+    },
   }
 )
 
@@ -288,13 +303,13 @@ snapshot(
   {
     title: 'umd and iife should preserve existing env.NODE_ENV',
     input: 'index.js',
-    cwd: fixture('format')
+    cwd: fixture('format'),
   },
   {
     output: {
       format: ['umd', 'umd-min', 'iife', 'iife-min'],
-      moduleName: 'dropNodeEnv'
+      moduleName: 'dropNodeEnv',
     },
-    env: { NODE_ENV: 'production' }
+    env: { NODE_ENV: 'production' },
   }
 )

--- a/test/stubs/@foo/rollup-plugin-bar/index.js
+++ b/test/stubs/@foo/rollup-plugin-bar/index.js
@@ -1,3 +1,6 @@
-module.exports = () => ({
-  name: '@foo/bar'
-})
+const name = '@foo/bar'
+
+module.exports = ({ callback } = {}) => {
+  callback(name)
+  return { name }
+}

--- a/test/stubs/@foo/rollup-plugin-bar/index.js
+++ b/test/stubs/@foo/rollup-plugin-bar/index.js
@@ -1,0 +1,3 @@
+module.exports = () => ({
+  name: '@foo/bar'
+})

--- a/test/stubs/@foo/rollup-plugin-bar/package.json
+++ b/test/stubs/@foo/rollup-plugin-bar/package.json
@@ -1,0 +1,6 @@
+{
+  "private": true,
+  "name": "@foo/rollup-plugin-bar",
+  "version": "0.0.0",
+  "main": "index.js"
+}


### PR DESCRIPTION
This PR alters plugin resolution to support scoped and official `@rollup` plugins:
```js
module.exports = {
  plugins: {
    '@extensionengine/tailor-ce': true,
    '@rollup/alias': { ... }
  }
};
```
This gets resolved as `@extensionengine/rollup-plugin-tailor-ce` and `@rollup/plugin-alias`. 🎉 

~**PS** I upgraded `boxen` & `caniuse-lite` just so I can actually build it.~