### PR TITLE
fix: babel/bubel exlude for symlinked node_modules

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -241,7 +241,7 @@ export class Bundler {
         config.plugins.babel !== false &&
         merge(
           {
-            exclude: 'node_modules/**',
+            exclude: /node_modules/,
             extensions: ['.js', '.jsx', '.mjs', '.ts', '.tsx', '.vue'],
             babelrc: config.babel.babelrc,
             configFile: config.babel.configFile,
@@ -254,7 +254,7 @@ export class Bundler {
         (config.plugins.buble || config.babel.minimal) &&
         merge(
           {
-            exclude: 'node_modules/**',
+            exclude: /node_modules/,
             include: '**/*.{js,mjs,jsx,ts,tsx,vue}',
             transforms: {
               modules: false,


### PR DESCRIPTION
Excluding `node_modules` needs to be a regex, otherwise symlink'd dependencies (i.e. yarn monorepo) won't work.