### PR TITLE
feat: support scoped rollup plugin (fix #275)

### DIFF
--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -10,7 +10,7 @@ module.exports = {
 }
 ```
 
-The name should be the package name of the plugin, without the `rollup-plugin-` prefix.
+If the package name starts with `rollup-plugin-`, the key should without the `rollup-plugin-` prefix. However, if the package name starts with `@rollup/`, use the full package name.
 
 The value will be used as its options, passing `true` is equivalent to an empty object, `false` is used to disable built-in plugins.
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -332,6 +332,8 @@ export class Bundler {
           ? nodeResolvePlugin
           : name === 'progress'
           ? progressPlugin
+          : name.startsWith('@rollup/')
+          ? this.localRequire(name)
           : isBuiltIn
           ? require(`rollup-plugin-${name}`)
           : this.localRequire(`rollup-plugin-${name}`)

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -242,6 +242,25 @@ module.exports = index;
 "
 `;
 
+exports[`scoped rollup plugin: scoped rollup plugin dist/index.js 1`] = `
+"'use strict';
+
+Object.defineProperty(exports, '__esModule', { value: true });
+
+const tt = 'is there anything?';
+
+function afun() {
+  return tt;
+}
+
+function another() {
+  return afun();
+}
+
+exports.another = another;
+"
+`;
+
 exports[`target:browser: target:browser dist/index.js 1`] = `
 "'use strict';
 

--- a/test/fixtures/package.json
+++ b/test/fixtures/package.json
@@ -1,6 +1,7 @@
 {
   "private": true,
   "dependencies": {
+    "@rollup/plugin-strip": "^1.3.2",
     "rollup-plugin-prettier": "^0.5.0",
     "rollup-plugin-strip": "^1.2.0",
     "rollup-plugin-typescript2": "^0.18.0",

--- a/test/fixtures/scoped-rollup-plugin/index.js
+++ b/test/fixtures/scoped-rollup-plugin/index.js
@@ -1,0 +1,13 @@
+const data = { foo: 'bar' }
+
+const tt = 'is there anything?'
+
+function afun() {
+  console.log('test')
+  return tt
+}
+
+export function another() {
+  console.log('two')
+  return afun()
+}

--- a/test/fixtures/yarn.lock
+++ b/test/fixtures/yarn.lock
@@ -2,6 +2,22 @@
 # yarn lockfile v1
 
 
+"@rollup/plugin-strip@^1.3.2":
+  version "1.3.2"
+  resolved "https://registry.npmjs.org/@rollup/plugin-strip/-/plugin-strip-1.3.2.tgz#9f52e99add99b835a4a3c14e02385f3726514923"
+  integrity sha512-dByULCvYdklJRJ50XqmA/ntyvVuVnnxOrgZ6cIIMBLLzQrsm9Ui15VD+6I8a11w8Ob9R7ySwYjFck9YCMzseKA==
+  dependencies:
+    "@rollup/pluginutils" "^3.0.4"
+    estree-walker "^1.0.1"
+    magic-string "^0.25.5"
+
+"@rollup/pluginutils@^3.0.4":
+  version "3.0.8"
+  resolved "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.0.8.tgz#4e94d128d94b90699e517ef045422960d18c8fde"
+  integrity sha512-rYGeAc4sxcZ+kPG/Tw4/fwJODC3IXHYDH4qusdN/b6aLw5LPUbzpecYbEJh4sVQGPFJxd2dBU4kc1H3oy9/bnw==
+  dependencies:
+    estree-walker "^1.0.1"
+
 "@vue/component-compiler-utils@^2.1.0":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@vue/component-compiler-utils/-/component-compiler-utils-2.3.0.tgz#4f580f1b28fc7685859d87ea0e92a1c0271c93da"
@@ -179,6 +195,11 @@ estree-walker@^0.5.2:
   version "0.5.2"
   resolved "https://registry.yarnpkg.com/estree-walker/-/estree-walker-0.5.2.tgz#d3850be7529c9580d815600b53126515e146dd39"
   integrity sha512-XpCnW/AE10ws/kDAs37cngSkvgIR8aN3G0MS85m7dUpuK2EREo9VJ00uvw6Dg/hXEpfsE1I1TvJOJr+Z+TL+ig==
+
+estree-walker@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz#31bc5d612c96b704106b477e6dd5d8aa138cb700"
+  integrity sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
 
 expand-brackets@^0.1.4:
   version "0.1.5"
@@ -448,6 +469,13 @@ magic-string@0.25.1, magic-string@^0.25.1:
   integrity sha512-sCuTz6pYom8Rlt4ISPFn6wuFodbKMIHUMv4Qko9P17dpxb7s52KJTmRuZZqHdGmLCK9AOcDare039nRIcfdkEg==
   dependencies:
     sourcemap-codec "^1.4.1"
+
+magic-string@^0.25.5:
+  version "0.25.7"
+  resolved "https://registry.npmjs.org/magic-string/-/magic-string-0.25.7.tgz#3f497d6fd34c669c6798dcb821f2ef31f5445051"
+  integrity sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+  dependencies:
+    sourcemap-codec "^1.4.4"
 
 math-random@^1.0.1:
   version "1.0.1"
@@ -736,6 +764,11 @@ sourcemap-codec@^1.4.1:
   version "1.4.3"
   resolved "https://registry.yarnpkg.com/sourcemap-codec/-/sourcemap-codec-1.4.3.tgz#0ba615b73ec35112f63c2f2d9e7c3f87282b0e33"
   integrity sha512-vFrY/x/NdsD7Yc8mpTJXuao9S8lq08Z/kOITHz6b7YbfI9xL8Spe5EvSQUHOI7SbpY8bRPr0U3kKSsPuqEGSfA==
+
+sourcemap-codec@^1.4.4:
+  version "1.4.8"
+  resolved "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz#ea804bd94857402e6992d05a38ef1ae35a9ab4c4"
+  integrity sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
 
 string-hash@^1.1.0:
   version "1.1.3"

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -215,6 +215,21 @@ snapshot(
 
 snapshot(
   {
+    title: 'scoped rollup plugin',
+    input: 'index.js',
+    cwd: fixture('scoped-rollup-plugin')
+  },
+  {
+    plugins: {
+      '@rollup/plugin-strip': {
+        functions: ['console.log']
+      }
+    }
+  }
+)
+
+snapshot(
+  {
     title: 'target:browser',
     input: 'index.js',
     cwd: fixture('target/browser')


### PR DESCRIPTION
- [x] test passed
- [x] new snapshot added
- [x] docs updated

This PR allows to use rollup plugin starts with `@rollup/`. Resolves #275.