### PR TITLE
Fix the rollup-plugin-typescript2 objectHashIgnoreUnknownHack warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "resolve-from": "^5.0.0",
     "rollup-plugin-typescript2": "^0.19.2",
     "semantic-release": "^15.13.3",
+    "semver": "^7.3.2",
     "slash": "^2.0.0",
     "string-width": "^3.0.0",
     "stringify-author": "^0.1.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8432,6 +8432,11 @@ semver@7.0.0:
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.0.0.tgz#5f3ca35761e47e05b206c6daff2cf814f0316b8e"
   integrity sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
 
+semver@^7.3.2:
+  version "7.3.2"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-7.3.2.tgz#604962b052b81ed0786aae84389ffba70ffd3938"
+  integrity sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ==
+
 semver@~5.3.0:
   version "5.3.0"
   resolved "https://registry.npmjs.org/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"


### PR DESCRIPTION
[rollup-plugin-typescript2](https://github.com/ezolenko/rollup-plugin-typescript2) < [v0.26](https://github.com/ezolenko/rollup-plugin-typescript2/releases/tag/0.26.0) needs the `objectHashIgnoreUnknownHack` option to be enabled to correctly handle async functions in the plugin configuration, but it's no longer needed (and causes a warning) if the user has a more recent version installed.

This PR detects the version of the plugin, if installed, and enables/disables the option accordingly.

Manually tested against rpt2 v0.25.3 and v0.27.0. 

Closes #305