### PR TITLE
fix: duplicated banner after minified (fix #346)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -331,6 +331,7 @@ export class Bundler {
       pluginsOptions.terser = {
         ...terserOptions,
         output: {
+          comments: false,
           ...terserOptions.output,
           // Add banner (if there is)
           preamble: banner,


### PR DESCRIPTION
By default, terser will preserve license(https://github.com/terser/terser#output-options). Set `terser.output.comments` to false to tell terser drop license, and we use bili's banner option.

