### PR TITLE
feat: support multiple bundle instance (resolve #12)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,15 +45,16 @@
     "@rollup/plugin-node-resolve": "^8.0.1",
     "@rollup/plugin-replace": "^2.3.3",
     "babel-plugin-transform-async-to-promises": "^0.8.15",
+    "cac": "^6.5.10",
     "chalk": "^4.1.0",
+    "joycon": "^2.2.5",
     "ora": "^4.0.4",
+    "p-series": "^2.1.0",
     "rollup": "^2.16.1",
     "rollup-plugin-hashbang": "^2.2.2",
     "rollup-plugin-postcss": "^3.1.2",
     "rollup-plugin-terser": "^6.1.0",
-    "v8-compile-cache": "^2.1.1",
-    "cac": "^6.5.10",
-    "joycon": "^2.2.5"
+    "v8-compile-cache": "^2.1.1"
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.8",

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -1,10 +1,13 @@
-import path from 'path'
 import fs from 'fs'
 import JoyCon from 'joycon'
+import path from 'path'
 import requireFromString from 'require-from-string'
 
+import logger from './logger'
+import { Config } from './types'
+
 const configLoader = new JoyCon({
-  stopDir: path.dirname(process.cwd())
+  stopDir: path.dirname(process.cwd()),
 })
 
 configLoader.addLoader({
@@ -21,17 +24,56 @@ configLoader.addLoader({
             require('@babel/preset-env'),
             {
               targets: {
-                node: 'current'
-              }
-            }
+                node: 'current',
+              },
+            },
           ],
-          id.endsWith('.ts') && require('@babel/preset-typescript')
-        ].filter(Boolean)
+          id.endsWith('.ts') && require('@babel/preset-typescript'),
+        ].filter(Boolean),
       }
     )
     const m = requireFromString(content && content.code ? content.code : '', id)
     return m.default || m
-  }
+  },
 })
 
+function loadConfig(
+  rootDir: string,
+  configFile?: string | boolean
+): {
+  fileConfig: Config
+  configPath?: string
+} {
+  let configPath: string | undefined = undefined
+
+  const fileConfig =
+    configFile === false
+      ? {}
+      : configLoader.loadSync({
+          files:
+            typeof configFile === 'string'
+              ? [configFile]
+              : [
+                  'bili.config.js',
+                  'bili.config.ts',
+                  '.bilirc.js',
+                  '.bilirc.ts',
+                  'package.json',
+                ],
+          cwd: rootDir,
+          packageKey: 'bili',
+        })
+
+  if (fileConfig.path) {
+    logger.debug(`Using config file:`, fileConfig.path)
+    configPath = fileConfig.path
+  }
+
+  return {
+    fileConfig: fileConfig.data || {},
+    configPath,
+  }
+}
+
+export { loadConfig }
 export default configLoader

--- a/src/config-loader.ts
+++ b/src/config-loader.ts
@@ -44,7 +44,7 @@ function loadConfig(
   fileConfig: Config
   configPath?: string
 } {
-  let configPath: string | undefined = undefined
+  let configPath: string | undefined
 
   const fileConfig =
     configFile === false

--- a/src/index.ts
+++ b/src/index.ts
@@ -731,7 +731,7 @@ async function runBundler(
   const run = async (config: BundleConfig) => {
     const bundler = new Bundler(cliConfig, config, options)
 
-    return await bundler
+    return bundler
       .run({
         write: true,
         watch: runOptions.watch,
@@ -745,9 +745,9 @@ async function runBundler(
 
   if (Array.isArray(fileConfig)) {
     if (runOptions.concurrent) {
-      return await Promise.all(fileConfig.map((c) => run(c)))
+      return Promise.all(fileConfig.map((c) => run(c)))
     } else {
-      return await series(fileConfig.map((c) => () => run(c)))
+      return series(fileConfig.map((c) => () => run(c)))
     }
   } else {
     return run(fileConfig)

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,7 @@ import {
 } from 'rollup'
 import merge from 'lodash/merge'
 import waterfall from 'p-waterfall'
+import series from 'p-series'
 import spinner from './spinner'
 import logger from './logger'
 import progressPlugin from './plugins/progress'
@@ -25,6 +26,7 @@ import getBanner from './utils/get-banner'
 import {
   Options,
   Config,
+  BundleConfig,
   NormalizedConfig,
   Format,
   ConfigEntryObject,
@@ -39,7 +41,7 @@ import {
 // TODO: PR to rollup-plugin-vue to allow this as an API option
 process.env.BUILD = 'production'
 
-interface RunOptions {
+export interface RunOptions {
   write?: boolean
   watch?: boolean
   concurrent?: boolean
@@ -72,7 +74,11 @@ export class Bundler {
   }
   bundles: Set<Assets>
 
-  constructor(config: Config, public options: Options = {}) {
+  constructor(
+    cliConfig: BundleConfig,
+    fileConfig: BundleConfig,
+    public options: Options = {}
+  ) {
     logger.setOptions({ logLevel: options.logLevel })
 
     this.rootDir = path.resolve(options.rootDir || '.')
@@ -91,56 +97,36 @@ export class Bundler {
       )
     }
 
-    const userConfig =
-      options.configFile === false
-        ? {}
-        : configLoader.loadSync({
-            files:
-              typeof options.configFile === 'string'
-                ? [options.configFile]
-                : [
-                    'bili.config.js',
-                    'bili.config.ts',
-                    '.bilirc.js',
-                    '.bilirc.ts',
-                    'package.json',
-                  ],
-            cwd: this.rootDir,
-            packageKey: 'bili',
-          })
-    if (userConfig.path) {
-      logger.debug(`Using config file:`, userConfig.path)
-      this.configPath = userConfig.path
-    }
-
+    this.configPath = options.configPath
     this.config = this.normalizeConfig(
-      config,
-      userConfig.data || {}
+      cliConfig,
+      fileConfig
     ) as NormalizedConfig
 
     this.bundles = new Set()
   }
 
-  normalizeConfig(config: Config, userConfig: Config) {
+  normalizeConfig(cliConfig: BundleConfig, fileConfig: BundleConfig) {
     const externals = new Set([
       ...Object.keys(this.pkg.data.dependencies || {}),
-      ...(Array.isArray(userConfig.externals)
-        ? userConfig.externals
-        : [userConfig.externals]),
-      ...(Array.isArray(config.externals)
-        ? config.externals
-        : [config.externals]),
+      ...(Array.isArray(fileConfig.externals)
+        ? fileConfig.externals
+        : [fileConfig.externals]),
+      ...(Array.isArray(cliConfig.externals)
+        ? cliConfig.externals
+        : [cliConfig.externals]),
     ])
-    const result = merge({}, userConfig, config, {
-      input: config.input || userConfig.input || 'src/index.js',
-      output: merge({}, userConfig.output, config.output),
-      plugins: merge({}, userConfig.plugins, config.plugins),
+
+    const result = merge({}, fileConfig, cliConfig, {
+      input: cliConfig.input || fileConfig.input || 'src/index.js',
+      output: merge({}, fileConfig.output, cliConfig.output),
+      plugins: merge({}, fileConfig.plugins, cliConfig.plugins),
       babel: merge(
         {
           asyncToPromises: true,
         },
-        userConfig.babel,
-        config.babel
+        fileConfig.babel,
+        cliConfig.babel
       ),
       externals: [...externals].filter(Boolean),
     })
@@ -736,4 +722,43 @@ function getDefaultFileName(format: RollupFormat) {
   return format === 'cjs' ? `[name][min][ext]` : `[name].[format][min][ext]`
 }
 
-export { Config, NormalizedConfig, Options, ConfigOutput }
+async function runBundler(
+  cliConfig: BundleConfig,
+  fileConfig: Config,
+  options: Options,
+  runOptions: RunOptions
+) {
+  const run = async (config: BundleConfig) => {
+    const bundler = new Bundler(cliConfig, config, options)
+
+    return await bundler
+      .run({
+        write: true,
+        watch: runOptions.watch,
+        concurrent: runOptions.concurrent,
+      })
+      .catch((err: any) => {
+        bundler.handleError(err)
+        process.exit(1)
+      })
+  }
+
+  if (Array.isArray(fileConfig)) {
+    if (runOptions.concurrent) {
+      return await Promise.all(fileConfig.map((c) => run(c)))
+    } else {
+      return await series(fileConfig.map((c) => () => run(c)))
+    }
+  } else {
+    return run(fileConfig)
+  }
+}
+
+export {
+  Config,
+  BundleConfig,
+  NormalizedConfig,
+  Options,
+  ConfigOutput,
+  runBundler,
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -2,12 +2,11 @@ import {
   ModuleFormat as RollupFormat,
   InputOptions,
   OutputOptions,
-  Plugin as RollupPlugin
+  Plugin as RollupPlugin,
 } from 'rollup'
 
 import { Banner } from './utils/get-banner'
 
-type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>
 type Diff<T extends keyof any, U extends keyof any> = ({ [P in T]: P } &
   { [P in U]: never } & { [x: string]: never })[T]
 type Overwrite<T, U> = Pick<T, Diff<keyof T, keyof U>> & U
@@ -169,7 +168,7 @@ export interface ConfigOutput {
   target?: OutputTarget
 }
 
-export interface Config {
+export interface BundleConfig {
   /**
    * Input files
    * @default `src/index.js`
@@ -290,6 +289,8 @@ export interface Config {
   extendRollupConfig?: ExtendRollupConfig
 }
 
+export type Config = BundleConfig | BundleConfig[]
+
 interface ConfigOutputOverwrite {
   /**
    * Output directory, always a string
@@ -330,7 +331,7 @@ export interface Options {
   /**
    * Use a custom config file rather than auto-loading bili.config.js
    */
-  configFile?: string | boolean
+  configPath?: string
   /**
    * The root directory to resolve files from
    * Useful for mono-repo

--- a/test/__snapshots__/index.test.ts.snap
+++ b/test/__snapshots__/index.test.ts.snap
@@ -276,6 +276,26 @@ module.exports = index;
 "
 `;
 
+exports[`multiple bundle instance: multiple bundle instance dist/index.umd.js 1`] = `
+"(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	(global = global || self, global.ins1 = factory());
+}(this, (function () { 'use strict';
+
+	var index = 42;
+
+	return index;
+
+})));
+"
+`;
+
+exports[`multiple bundle instance: multiple bundle instance dist/index.umd.min.js 1`] = `
+"!function(e,n){\\"object\\"==typeof exports&&\\"undefined\\"!=typeof module?module.exports=n():\\"function\\"==typeof define&&define.amd?define(n):(e=e||self).ins2=n()}(this,(function(){\\"use strict\\";return 42}));
+"
+`;
+
 exports[`target:browser: target:browser dist/index.js 1`] = `
 "'use strict';
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1375,6 +1375,11 @@
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
   integrity sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
 
+"@sindresorhus/is@^0.15.0":
+  version "0.15.0"
+  resolved "https://registry.npmjs.org/@sindresorhus/is/-/is-0.15.0.tgz#96915baa05e6a6a1d137badf4984d3fc05820bb6"
+  integrity sha512-lu8BpxjAtRCAo5ifytTpCPCj99LF7o/2Myn+NXyNCBqvPYn7Pjd76AMmUB5l7XF1U6t0hcWrlEM5ESufW7wAeA==
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.0"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.0.tgz#c8d68821a854c555bba172f3b06959a0039b236d"
@@ -7562,7 +7567,7 @@ p-queue@^6.3.0:
     eventemitter3 "^4.0.0"
     p-timeout "^3.1.0"
 
-p-reduce@^2.0.0:
+p-reduce@^2.0.0, p-reduce@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/p-reduce/-/p-reduce-2.1.0.tgz#09408da49507c6c274faa31f28df334bc712b64a"
   integrity sha512-2USApvnsutq8uoxZBGbbWM0JIYLiEMJ9RlaN7fAzVNb9OZN0SHjjTTfIcb667XynS5Y1VhwDJVDa72TnPzAYWw==
@@ -7574,6 +7579,14 @@ p-retry@^4.0.0:
   dependencies:
     "@types/retry" "^0.12.0"
     retry "^0.12.0"
+
+p-series@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/p-series/-/p-series-2.1.0.tgz#7035b3a81e2644d4ba407c1ebbc21776e353fa29"
+  integrity sha512-vEAnkG1ikRT1kPBrKwpj7AFYQkd1hjt/oHeppxtpoPxy5gEt+OWiHZJN3tMqvFa+UJfVwO3lwHoMUpMYBLKnaQ==
+  dependencies:
+    "@sindresorhus/is" "^0.15.0"
+    p-reduce "^2.1.0"
 
 p-timeout@^3.1.0:
   version "3.2.0"


### PR DESCRIPTION
Now user can export an array in config file to run multiple bundle instances. #12

e.g.

```ts
import { Config } from 'bili'

const config: Config = [
  {
    input: 'src/index.js',
    output: {
      dir: 'dist1',
      format: ['umd', 'umd-min', 'iife', 'iife-min', 'cjs', 'esm'],
      moduleName: 'aaa',
    },
  },
  {
    input: 'src/index.js',
    output: {
      dir: 'dist2',
      format: ['umd', 'umd-min', 'iife', 'iife-min', 'cjs', 'esm'],
      moduleName: 'bbb',
    },
  },
]

export default config
```

- [x] new test case added

- `Bundler` will not responsible for loading config file, it only accepts bundle config. More like rollup API usage.
- A new function `runBundler` run bundlers. It could be also used in test file.
- TODO: `cliConfig` and `fileConfig` should be merged before passing into Bundler.

Not sure will this PR bring breaking change. For user who uses API, this will be a breaking change. But API usage is not listed in the documentation. If so, may this PR be a candidate for next major release.
