### PR TITLE
Silence `prefer_named_exports` warning when there are no named exports

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -463,7 +463,7 @@ export class Bundler {
       // Since we only output to `.js` now
       // Probably remove it in the future
       .replace(/\[ext\]/, '.js')
- 
+
     if (rollupFormat === 'esm')  {
       fileName = fileName.replace(/\[format\]/, 'esm')
     }
@@ -503,6 +503,7 @@ export class Bundler {
         entryFileNames: fileName,
         name: config.output.moduleName,
         banner,
+        exports: 'auto',
         sourcemap:
           typeof config.output.sourceMap === 'boolean'
             ? config.output.sourceMap


### PR DESCRIPTION
Set rollup's [`output.exports`](https://rollupjs.org/guide/en/#outputexports) option to "auto" to avoid warnings about default exports when there are no named exports. Closes #425.