### PR TITLE
Improve documentation for output formats

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,7 @@ export type OutputTarget = 'node' | 'browser'
 
 export interface ConfigOutput {
   /**
-   * Output format(s). You can append `min` to the format to generate minified bundle.
+   * Output format(s). You can append `-min` to the format to generate minified bundle.
    *
    * @default `cjs`
    * @cli `--format <format>`


### PR DESCRIPTION
You get from the valid `cjs` to `cjs-min` by appending `-min`, not only `min`.