### PR TITLE
Document runtime dependencies for building vue

### DIFF
--- a/docs/recipes/vue-component.md
+++ b/docs/recipes/vue-component.md
@@ -4,6 +4,7 @@ If one of your input files ends with `.vue`, Bili will automatically use [rollup
 
 ```bash
 yarn add rollup-plugin-vue vue-template-compiler vue --dev
+yarn add vue-runtime-helpers
 
 bili src/MyComponent.vue
 ```


### PR DESCRIPTION
In the latest versions of `rollup-plugin-vue` the normalizers from `vue-runtime-helpers` are not inlined any more.
So they need to be added as dependencies.

This resolves #221.

See also https://github.com/vuejs/rollup-plugin-vue/issues/308#issuecomment-557139789