### PR TITLE
fix(docs): typo

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,7 @@ export type OutputTarget = 'node' | 'browser'
 
 export interface ConfigOutput {
   /**
-   * Output format(s). You can append `min` to the format to generate minified bundle.
+   * Output format(s). You can append `-min` to the format to generate minified bundle.
    *
    * @default `cjs`
    * @cli `--format <format>`


### PR DESCRIPTION
To get a single output minified, you need `-min`, e.g. `bili --format umd-min`.  Appending just "min" (as in, `bili --format umdmin`) results in an error about an unsupported format.

This fixes the docs here: https://bili.egoist.sh/api/interfaces/configoutput.html 

![image](https://user-images.githubusercontent.com/1072292/133375525-ae52f310-95d0-4750-9bde-b7d50475cfef.png)
