### PR TITLE
Surface build error message

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -680,7 +680,7 @@ export class Bundler {
 
   handleError(err: any) {
     if (err.stack) {
-      console.error()
+      console.error(colors.blold(err.message))
       console.error(colors.bold(colors.red('Stack Trace:')))
       console.error(colors.dim(err.stack))
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -680,7 +680,7 @@ export class Bundler {
 
   handleError(err: any) {
     if (err.stack) {
-      console.error(colors.blold(err.message))
+      console.error(colors.bold(err.message))
       console.error(colors.bold(colors.red('Stack Trace:')))
       console.error(colors.dim(err.stack))
     }


### PR DESCRIPTION
If a build throws an error, the message inside that error can be very helpful in debugging failures.  